### PR TITLE
new interface: supportedModelInfo & add seeds in tx2img&img2img's result

### DIFF
--- a/dan-web-server/src/controllers/SdController.ts
+++ b/dan-web-server/src/controllers/SdController.ts
@@ -116,6 +116,11 @@ export default class SdControler {
     responseHandler.success(context, taskStatistics);
   }
 
+  async supportedModelInfo(context: Context) {
+    const supportedModelInfo = await this.sdService.supportedModelInfo();
+    responseHandler.success(context, supportedModelInfo);
+  }
+
   private async getAccount(context: Context) {
     const userId = context.session?.authUserInfo?.id;
     const apiKey = context.request.headers?.authorization?.replace('Bearer ', '') as string;
@@ -143,6 +148,7 @@ export default class SdControler {
     router.post('/task/status', this.taskStatus.bind(this));
     router.post('/statistics', this.taskStatistics.bind(this));
     router.get('/statistics', this.taskStatistics.bind(this));
+    router.get('/supportedModelInfo', this.supportedModelInfo.bind(this));
     return router;
   }
 }

--- a/dan-web-server/src/services/SdService.ts
+++ b/dan-web-server/src/services/SdService.ts
@@ -205,6 +205,7 @@ export default class SdService {
 
     // update task status
     const images = resultObj.images;
+    const seeds = JSON.parse(resultObj.info).all_seeds;
     let taskStatus: number;
     if (_.isNaN(images) || _.isNull(images) || _.isEmpty(images)) {
       taskStatus = NodeTaskStatus.Failure;
@@ -215,6 +216,7 @@ export default class SdService {
       taskId: taskId as string,
       queuePosition: 0,
       status: taskStatus,
+      seeds: seeds,
     };
     return _.assign(taskStatusResult, _.omit(resultObj, 'info', 'parameters'));
   }

--- a/dan-web-server/src/services/SdService.ts
+++ b/dan-web-server/src/services/SdService.ts
@@ -131,6 +131,13 @@ export default class SdService {
     return { totalCount, countInLast24Hours, countInLastWeek };
   }
 
+  async supportedModelInfo() {
+    const Models = Object.entries(config.sdConfig.kValidModels).map(([hash, name]) => ({ name, hash }));
+    const LoRAs = Object.entries(config.sdConfig.kValidLoras).map(([hash, name]) => ({ name, hash }));
+    const Samplers = config.sdConfig.kValidSamplers;
+    return { Models, LoRAs, Samplers };
+  }
+
   private async executeTaskWrapper(taskInfo: JsonObject) {
     const { taskId, taskType } = taskInfo;
     try {


### PR DESCRIPTION
The supportedModelInfo interface  let user knows which Models,LoRAs and Samplers are supported in DAN.
Seeds in the return let users know the seed in the picture, when seed in the params is -1.